### PR TITLE
[164135944]- Add badges on README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Politico -  Andela Developer Challenge
 
-[![Build Status](https://travis-ci.org/niyobobo/Politico.svg?branch=)](https://travis-ci.org/niyobobo/Politico) [![Coverage Status](https://coveralls.io/repos/github/niyobobo/Politico/badge.svg?branch=ft-api)](https://coveralls.io/github/niyobobo/Politico?branch=ft-api) [![Code Climate](https://codeclimate.com/github/codeclimate/codeclimate/badges/gpa.svg)](https://codeclimate.com/github/niyobobo/Politico)
+[![Build Status](https://travis-ci.org/niyobobo/Politico.svg?branch=develop)](https://travis-ci.org/niyobobo/Politico) [![Coverage Status](https://coveralls.io/repos/github/niyobobo/Politico/badge.svg?branch=develop)](https://coveralls.io/github/niyobobo/Politico?branch=develop) [![Code Climate](https://codeclimate.com/github/codeclimate/codeclimate/badges/gpa.svg)](https://codeclimate.com/github/niyobobo/Politico)
 
 # Description
 


### PR DESCRIPTION
#### What does this PR do?
* Fixing issue about sending test coverage to coveralls

#### Description of Task to be completed?
* Show coverage statistics badge of develop branch
* Show build status badge with Travis CI build status of develop branch

#### How should this be manually tested?
Checking README file

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#164135944 -(Chore) Github repo's README should be able to show badges related to develop branch  )](https://www.pivotaltracker.com/n/projects/2240018)